### PR TITLE
Implement core nw-check pipeline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.5
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,23 @@
 
 - `nw-check --devices devices.csv --tobe tobe.csv --out-dir out/`
 
+### Getting Started
+
+1. Create a virtual environment and install dependencies:
+   - `python -m venv .venv`
+   - `source .venv/bin/activate`
+   - `python -m pip install -e .[dev]`
+2. Ensure the `snmpwalk` CLI is available on your PATH for LLDP collection.
+3. Run the CLI with your inventory and intent CSVs:
+   - `nw-check --devices devices.csv --tobe tobe.csv --out-dir out/`
+
+### Development Commands
+
+- Tests: `python -m pytest`
+- Lint: `python -m pylint nw_check`
+- Format: `python -m ruff format`
+- Static analysis: `python -m mypy nw_check`
+
 ### Arguments
 
 - `--devices`: path to device inventory CSV

--- a/nw_check/__init__.py
+++ b/nw_check/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""nw-check package entrypoint."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/nw_check/cli.py
+++ b/nw_check/cli.py
@@ -1,0 +1,86 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""CLI entrypoint."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from nw_check.diff import diff_links
+from nw_check.inventory import load_device_inventory, load_link_intents
+from nw_check.link_infer import deduplicate_links
+from nw_check.lldp_snmp import collect_lldp_observations
+from nw_check.output import write_asis_links, write_diff_links, write_summary
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build argument parser."""
+
+    parser = argparse.ArgumentParser(description="nw-check")
+    parser.add_argument("--devices", required=True, help="path to device inventory CSV")
+    parser.add_argument("--tobe", required=True, help="path to To-Be wiring CSV")
+    parser.add_argument("--out-dir", required=True, help="output directory")
+    parser.add_argument("--snmp-timeout", type=int, default=2, help="SNMP timeout seconds")
+    parser.add_argument("--snmp-retries", type=int, default=1, help="SNMP retries")
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["INFO", "DEBUG", "WARN"],
+        help="log level",
+    )
+    return parser
+
+
+def configure_logging(level: str) -> None:
+    """Configure logging."""
+
+    logging.basicConfig(level=getattr(logging, level), format="%(levelname)s %(message)s")
+
+
+def main() -> int:
+    """Run nw-check."""
+
+    parser = build_parser()
+    args = parser.parse_args()
+    configure_logging(args.log_level)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    devices = load_device_inventory(args.devices)
+    tobe_links = load_link_intents(args.tobe)
+
+    observations, errors = collect_lldp_observations(
+        devices=devices,
+        timeout=args.snmp_timeout,
+        retries=args.snmp_retries,
+    )
+    _LOGGER.info("Collected %s observations", len(observations))
+
+    asis_links = deduplicate_links(observations)
+    diffs = diff_links(tobe_links, asis_links)
+
+    write_asis_links(out_dir / "asis_links.csv", asis_links)
+    write_diff_links(out_dir / "diff_links.csv", diffs)
+    write_summary(out_dir / "summary.txt", diffs, errors)
+
+    if errors:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nw_check/diff.py
+++ b/nw_check/diff.py
@@ -1,0 +1,200 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""To-Be vs As-Is diff logic."""
+
+from __future__ import annotations
+
+from nw_check.models import UNKNOWN_VALUE, AsIsLink, LinkDiff, LinkIntent
+
+STATUS_EXACT_MATCH = "EXACT_MATCH"
+STATUS_PORT_MISMATCH = "PORT_MISMATCH"
+STATUS_DEVICE_MISMATCH = "DEVICE_MISMATCH"
+STATUS_MISSING_ASIS = "MISSING_ASIS"
+STATUS_PARTIAL_OBSERVED = "PARTIAL_OBSERVED"
+STATUS_UNKNOWN = "UNKNOWN"
+
+
+def diff_links(tobe_links: list[LinkIntent], asis_links: list[AsIsLink]) -> list[LinkDiff]:
+    """Compare To-Be links against As-Is links."""
+
+    asis_by_key = {
+        _canonical_key(link.device_a, link.port_a, link.device_b, link.port_b): link
+        for link in asis_links
+    }
+
+    diff_results: list[LinkDiff] = []
+    for intent in tobe_links:
+        key = _canonical_key(
+            intent.device_a,
+            intent.port_a_norm,
+            intent.device_b,
+            intent.port_b_norm,
+        )
+        exact = asis_by_key.get(key)
+        if exact:
+            diff_results.append(
+                LinkDiff(
+                    tobe_link=intent,
+                    asis_link=exact,
+                    status=STATUS_EXACT_MATCH,
+                    reason="normalized ports matched",
+                )
+            )
+            continue
+
+        candidates = _find_candidates(intent, asis_links)
+        if len(candidates) > 1:
+            diff_results.append(
+                LinkDiff(
+                    tobe_link=intent,
+                    asis_link=None,
+                    status=STATUS_UNKNOWN,
+                    reason=_format_candidates(candidates),
+                )
+            )
+            continue
+
+        if candidates:
+            candidate = candidates[0]
+            if _is_partial(candidate):
+                diff_results.append(
+                    LinkDiff(
+                        tobe_link=intent,
+                        asis_link=candidate,
+                        status=STATUS_PARTIAL_OBSERVED,
+                        reason="partial LLDP observation",
+                    )
+                )
+                continue
+
+        if _has_device_match(intent, asis_links):
+            reason = _port_mismatch_reason(intent, asis_links)
+            diff_results.append(
+                LinkDiff(
+                    tobe_link=intent,
+                    asis_link=None,
+                    status=STATUS_PORT_MISMATCH,
+                    reason=reason,
+                )
+            )
+            continue
+
+        if _has_port_match(intent, asis_links):
+            reason = _device_mismatch_reason(intent, asis_links)
+            diff_results.append(
+                LinkDiff(
+                    tobe_link=intent,
+                    asis_link=None,
+                    status=STATUS_DEVICE_MISMATCH,
+                    reason=reason,
+                )
+            )
+            continue
+
+        diff_results.append(
+            LinkDiff(
+                tobe_link=intent,
+                asis_link=None,
+                status=STATUS_MISSING_ASIS,
+                reason="no lldp observation",
+            )
+        )
+
+    return diff_results
+
+
+def _canonical_key(
+    device_a: str, port_a: str, device_b: str, port_b: str
+) -> tuple[str, str, str, str]:
+    """Canonicalize key for undirected matching."""
+
+    left = (device_a, port_a)
+    right = (device_b, port_b)
+    if left <= right:
+        return device_a, port_a, device_b, port_b
+    return device_b, port_b, device_a, port_a
+
+
+def _find_candidates(intent: LinkIntent, asis_links: list[AsIsLink]) -> list[AsIsLink]:
+    """Find partial candidates for a To-Be link."""
+
+    candidates: list[AsIsLink] = []
+    for link in asis_links:
+        devices_match = {intent.device_a, intent.device_b} == {
+            link.device_a,
+            link.device_b,
+        }
+        ports_match = {intent.port_a_norm, intent.port_b_norm} == {
+            link.port_a,
+            link.port_b,
+        }
+        if devices_match or ports_match:
+            candidates.append(link)
+    return candidates
+
+
+def _format_candidates(candidates: list[AsIsLink]) -> str:
+    """Format candidate list for UNKNOWN reason."""
+
+    details = ", ".join(
+        f"{link.device_a}:{link.port_a}-{link.device_b}:{link.port_b}" for link in candidates
+    )
+    return f"multiple candidates: {details}"
+
+
+def _is_partial(link: AsIsLink) -> bool:
+    """Check if a link is partially observed."""
+
+    return link.confidence == "partial" or UNKNOWN_VALUE in {
+        link.device_a,
+        link.device_b,
+        link.port_a,
+        link.port_b,
+    }
+
+
+def _has_device_match(intent: LinkIntent, asis_links: list[AsIsLink]) -> bool:
+    """Check if any As-Is link matches the devices."""
+
+    target = {intent.device_a, intent.device_b}
+    return any({link.device_a, link.device_b} == target for link in asis_links)
+
+
+def _has_port_match(intent: LinkIntent, asis_links: list[AsIsLink]) -> bool:
+    """Check if any As-Is link matches the ports."""
+
+    target = {intent.port_a_norm, intent.port_b_norm}
+    return any({link.port_a, link.port_b} == target for link in asis_links)
+
+
+def _port_mismatch_reason(intent: LinkIntent, asis_links: list[AsIsLink]) -> str:
+    """Build a PORT_MISMATCH reason string."""
+
+    matches = [
+        link
+        for link in asis_links
+        if {link.device_a, link.device_b} == {intent.device_a, intent.device_b}
+    ]
+    ports = ", ".join(f"{link.port_a}-{link.port_b}" for link in matches)
+    return f"remote port differs: {ports}" if ports else "remote port differs"
+
+
+def _device_mismatch_reason(intent: LinkIntent, asis_links: list[AsIsLink]) -> str:
+    """Build a DEVICE_MISMATCH reason string."""
+
+    matches = [
+        link
+        for link in asis_links
+        if {link.port_a, link.port_b} == {intent.port_a_norm, intent.port_b_norm}
+    ]
+    devices = ", ".join(f"{link.device_a}-{link.device_b}" for link in matches)
+    return f"remote device differs: {devices}" if devices else "remote device differs"

--- a/nw_check/inventory.py
+++ b/nw_check/inventory.py
@@ -1,0 +1,64 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""Inventory and To-Be CSV parsing."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from nw_check.models import Device, LinkIntent
+from nw_check.normalize import normalize_interface_name
+
+
+def load_device_inventory(path: str | Path) -> list[Device]:
+    """Load device inventory CSV."""
+
+    devices: list[Device] = []
+    with Path(path).open(encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            device = Device(
+                name=(row.get("name") or "").strip(),
+                mgmt_ip=(row.get("mgmt_ip") or "").strip(),
+                snmp_version=(row.get("snmp_version") or "").strip(),
+                snmp_community=(row.get("snmp_community") or "").strip() or None,
+                snmp_user=(row.get("snmp_user") or "").strip() or None,
+                snmp_auth=(row.get("snmp_auth") or "").strip() or None,
+                snmp_priv=(row.get("snmp_priv") or "").strip() or None,
+            )
+            devices.append(device)
+    return devices
+
+
+def load_link_intents(path: str | Path) -> list[LinkIntent]:
+    """Load To-Be wiring CSV."""
+
+    intents: list[LinkIntent] = []
+    with Path(path).open(encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            device_a = (row.get("device_a") or "").strip()
+            port_a_raw = (row.get("port_a") or "").strip()
+            device_b = (row.get("device_b") or "").strip()
+            port_b_raw = (row.get("port_b") or "").strip()
+            intents.append(
+                LinkIntent(
+                    device_a=device_a,
+                    port_a_raw=port_a_raw,
+                    port_a_norm=normalize_interface_name(port_a_raw),
+                    device_b=device_b,
+                    port_b_raw=port_b_raw,
+                    port_b_norm=normalize_interface_name(port_b_raw),
+                )
+            )
+    return intents

--- a/nw_check/link_infer.py
+++ b/nw_check/link_infer.py
@@ -1,0 +1,81 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""Link inference and deduplication."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from nw_check.models import UNKNOWN_VALUE, AsIsLink, LinkObservation
+
+
+def deduplicate_links(observations: list[LinkObservation]) -> list[AsIsLink]:
+    """Deduplicate directional observations into undirected links."""
+
+    grouped: dict[tuple[str, str, str, str], list[LinkObservation]] = defaultdict(list)
+    for obs in observations:
+        device_a, port_a, device_b, port_b = _canonicalize(
+            obs.local_device,
+            obs.local_port_norm,
+            obs.remote_device_name or obs.remote_device_id,
+            obs.remote_port_norm,
+        )
+        grouped[(device_a, port_a, device_b, port_b)].append(obs)
+
+    deduped: list[AsIsLink] = []
+    for (device_a, port_a, device_b, port_b), obs_list in grouped.items():
+        confidence = _merge_confidence(obs_list)
+        evidence = sorted({obs.source for obs in obs_list})
+        deduped.append(
+            AsIsLink(
+                device_a=device_a,
+                port_a=port_a,
+                device_b=device_b,
+                port_b=port_b,
+                confidence=confidence,
+                evidence=tuple(evidence),
+            )
+        )
+
+    return sorted(
+        deduped, key=lambda link: (link.device_a, link.port_a, link.device_b, link.port_b)
+    )
+
+
+def _canonicalize(
+    device_a: str,
+    port_a: str,
+    device_b: str,
+    port_b: str,
+) -> tuple[str, str, str, str]:
+    """Canonicalize link endpoints for deduplication."""
+
+    device_a = device_a or UNKNOWN_VALUE
+    device_b = device_b or UNKNOWN_VALUE
+    port_a = port_a or UNKNOWN_VALUE
+    port_b = port_b or UNKNOWN_VALUE
+    left = (device_a, port_a)
+    right = (device_b, port_b)
+    if left <= right:
+        return device_a, port_a, device_b, port_b
+    return device_b, port_b, device_a, port_a
+
+
+def _merge_confidence(observations: list[LinkObservation]) -> str:
+    """Merge confidence across observations."""
+
+    confidences = {obs.confidence for obs in observations}
+    if "observed" in confidences and len(observations) > 1:
+        return "observed"
+    if "partial" in confidences:
+        return "partial"
+    return "unknown"

--- a/nw_check/lldp_snmp.py
+++ b/nw_check/lldp_snmp.py
@@ -1,0 +1,233 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""LLDP collection via SNMP using the snmpwalk CLI."""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from nw_check.models import UNKNOWN_VALUE, Device, LinkObservation
+from nw_check.normalize import normalize_interface_name
+
+_LOGGER = logging.getLogger(__name__)
+
+LLDP_REM_TABLE = "LLDP-MIB::lldpRemTable"
+LLDP_LOC_PORT_TABLE = "LLDP-MIB::lldpLocPortTable"
+
+
+@dataclass(frozen=True)
+class DeviceCollectionResult:
+    """Result of collecting LLDP information from a single device."""
+
+    observations: list[LinkObservation]
+    errors: list[str]
+
+
+def collect_lldp_observations(
+    devices: Iterable[Device],
+    timeout: int,
+    retries: int,
+    snmpwalk_cmd: str = "snmpwalk",
+) -> tuple[list[LinkObservation], list[str]]:
+    """Collect LLDP neighbor data from devices via SNMP walk."""
+
+    all_observations: list[LinkObservation] = []
+    failed_devices: list[str] = []
+    for device in devices:
+        result = _collect_for_device(device, timeout, retries, snmpwalk_cmd)
+        all_observations.extend(result.observations)
+        if result.errors:
+            failed_devices.append(device.name)
+    return all_observations, failed_devices
+
+
+def _collect_for_device(
+    device: Device,
+    timeout: int,
+    retries: int,
+    snmpwalk_cmd: str,
+) -> DeviceCollectionResult:
+    """Collect LLDP data for a single device using snmpwalk."""
+
+    errors: list[str] = []
+    if not device.snmp_community:
+        errors.append("SNMP_AUTH_FAILED")
+        return DeviceCollectionResult([], errors)
+
+    if not _command_exists(snmpwalk_cmd):
+        errors.append("SNMP_OID_UNSUPPORTED")
+        return DeviceCollectionResult([], errors)
+
+    loc_port_output = _run_snmpwalk(snmpwalk_cmd, device, timeout, retries, LLDP_LOC_PORT_TABLE)
+    if loc_port_output is None:
+        errors.append("SNMP_TIMEOUT")
+        return DeviceCollectionResult([], errors)
+
+    rem_output = _run_snmpwalk(snmpwalk_cmd, device, timeout, retries, LLDP_REM_TABLE)
+    if rem_output is None:
+        errors.append("SNMP_TIMEOUT")
+        return DeviceCollectionResult([], errors)
+
+    loc_ports = _parse_loc_port_table(loc_port_output)
+    rem_rows = _parse_rem_table(rem_output)
+    if not rem_rows:
+        errors.append("LLDP_TABLE_EMPTY")
+        return DeviceCollectionResult([], errors)
+
+    observations: list[LinkObservation] = []
+    for row in rem_rows:
+        local_port_raw = loc_ports.get(row.local_port) or UNKNOWN_VALUE
+        local_port_norm = normalize_interface_name(local_port_raw)
+        remote_port_norm = normalize_interface_name(row.remote_port)
+        remote_device_name = row.remote_sys_name or UNKNOWN_VALUE
+        confidence = "observed"
+        error_list: list[str] = []
+        if remote_device_name == UNKNOWN_VALUE or row.remote_port == UNKNOWN_VALUE:
+            confidence = "partial"
+            error_list.append("LLDP_PARTIAL_ROW")
+        observations.append(
+            LinkObservation(
+                local_device=device.name,
+                local_port_raw=local_port_raw,
+                local_port_norm=local_port_norm,
+                remote_device_id=row.remote_chassis,
+                remote_device_name=remote_device_name,
+                remote_port_raw=row.remote_port,
+                remote_port_norm=remote_port_norm,
+                source="lldp",
+                confidence=confidence,
+                errors=tuple(error_list),
+            )
+        )
+
+    return DeviceCollectionResult(observations, errors)
+
+
+def _command_exists(command: str) -> bool:
+    """Check if a command exists on PATH."""
+
+    return Path(command).is_file() or bool(shutil.which(command))
+
+
+def _run_snmpwalk(
+    snmpwalk_cmd: str,
+    device: Device,
+    timeout: int,
+    retries: int,
+    oid: str,
+) -> list[str] | None:
+    """Run snmpwalk and return output lines, or None on failure."""
+
+    command = [
+        snmpwalk_cmd,
+        "-v",
+        device.snmp_version,
+        "-c",
+        device.snmp_community or "",
+        "-t",
+        str(timeout),
+        "-r",
+        str(retries),
+        device.mgmt_ip,
+        oid,
+    ]
+    _LOGGER.debug("Running snmpwalk: %s", " ".join(command))
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        _LOGGER.error("Failed to run snmpwalk: %s", exc)
+        return None
+
+    if result.returncode != 0:
+        _LOGGER.error("snmpwalk failed for %s: %s", device.name, result.stderr)
+        return None
+
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+@dataclass(frozen=True)
+class RemRow:
+    """Parsed LLDP remote row."""
+
+    local_port: str
+    remote_chassis: str
+    remote_port: str
+    remote_sys_name: str
+
+
+def _parse_loc_port_table(lines: Iterable[str]) -> dict[str, str]:
+    """Parse lldpLocPortTable output into a map of port index to id."""
+
+    port_map: dict[str, str] = {}
+    pattern = re.compile(r"lldpLocPortId\.(?P<index>[\d.]+)\s*=\s*\w+:\s*(?P<value>.+)")
+    for line in lines:
+        match = pattern.search(line)
+        if match:
+            port_map[match.group("index")] = _strip_snmp_value(match.group("value"))
+    return port_map
+
+
+def _parse_rem_table(lines: Iterable[str]) -> list[RemRow]:
+    """Parse lldpRemTable output into rows grouped by local port."""
+
+    rows: dict[str, dict[str, str]] = {}
+    patterns = {
+        "remote_chassis": re.compile(
+            r"lldpRemChassisId\.(?P<index>[\d.]+)\s*=\s*\w+:\s*(?P<value>.+)"
+        ),
+        "remote_port": re.compile(r"lldpRemPortId\.(?P<index>[\d.]+)\s*=\s*\w+:\s*(?P<value>.+)"),
+        "remote_sys_name": re.compile(
+            r"lldpRemSysName\.(?P<index>[\d.]+)\s*=\s*\w+:\s*(?P<value>.+)"
+        ),
+    }
+    for line in lines:
+        for key, pattern in patterns.items():
+            match = pattern.search(line)
+            if match:
+                index = match.group("index")
+                values = rows.get(index)
+                if values is None:
+                    values = {}
+                    rows[index] = values
+                values[key] = _strip_snmp_value(match.group("value"))
+    rem_rows: list[RemRow] = []
+    for index, values in rows.items():
+        local_port = index.split(".")[1] if "." in index else index
+        rem_rows.append(
+            RemRow(
+                local_port=local_port,
+                remote_chassis=values.get("remote_chassis", UNKNOWN_VALUE),
+                remote_port=values.get("remote_port", UNKNOWN_VALUE),
+                remote_sys_name=values.get("remote_sys_name", UNKNOWN_VALUE),
+            )
+        )
+    return rem_rows
+
+
+def _strip_snmp_value(raw_value: str) -> str:
+    """Normalize snmpwalk values by removing quotes and hex wrappers."""
+
+    value = raw_value.strip().strip('"')
+    if value.startswith("0x"):
+        return value
+    return value

--- a/nw_check/models.py
+++ b/nw_check/models.py
@@ -1,0 +1,82 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""Data models for nw-check."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+UNKNOWN_VALUE = "unknown"
+
+
+@dataclass(frozen=True)
+class Device:
+    """Device inventory record."""
+
+    name: str
+    mgmt_ip: str
+    snmp_version: str
+    snmp_community: str | None = None
+    snmp_user: str | None = None
+    snmp_auth: str | None = None
+    snmp_priv: str | None = None
+
+
+@dataclass(frozen=True)
+class LinkObservation:
+    """Directional LLDP observation collected from a device."""
+
+    local_device: str
+    local_port_raw: str
+    local_port_norm: str
+    remote_device_id: str
+    remote_device_name: str
+    remote_port_raw: str
+    remote_port_norm: str
+    source: str
+    confidence: str
+    errors: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class AsIsLink:
+    """Deduplicated LLDP link."""
+
+    device_a: str
+    port_a: str
+    device_b: str
+    port_b: str
+    confidence: str
+    evidence: Sequence[str]
+
+
+@dataclass(frozen=True)
+class LinkIntent:
+    """Desired wiring intent (To-Be)."""
+
+    device_a: str
+    port_a_raw: str
+    port_a_norm: str
+    device_b: str
+    port_b_raw: str
+    port_b_norm: str
+
+
+@dataclass(frozen=True)
+class LinkDiff:
+    """Comparison result between To-Be and As-Is links."""
+
+    tobe_link: LinkIntent
+    asis_link: AsIsLink | None
+    status: str
+    reason: str

--- a/nw_check/normalize.py
+++ b/nw_check/normalize.py
@@ -1,0 +1,50 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""Normalization utilities."""
+
+from __future__ import annotations
+
+import re
+
+from nw_check.models import UNKNOWN_VALUE
+
+_PREFIX_MAP: tuple[tuple[str, str], ...] = (
+    (r"^ethernet", "Eth"),
+    (r"^eth", "Eth"),
+    (r"^gigabitethernet", "Eth"),
+    (r"^gigabit", "Eth"),
+    (r"^gi", "Eth"),
+    (r"^tengigabitethernet", "Eth"),
+    (r"^tengigabit", "Eth"),
+    (r"^te", "Eth"),
+)
+
+
+def normalize_interface_name(raw_name: str) -> str:
+    """Normalize interface names to a canonical form."""
+
+    if not raw_name:
+        return UNKNOWN_VALUE
+
+    cleaned = re.sub(r"\s+", "", raw_name.strip())
+    if not cleaned:
+        return UNKNOWN_VALUE
+
+    normalized = cleaned.replace("-", "/")
+    lowered = normalized.lower()
+    for pattern, prefix in _PREFIX_MAP:
+        match = re.match(pattern, lowered)
+        if match:
+            suffix = normalized[match.end() :]
+            return f"{prefix}{suffix}"
+
+    return normalized

--- a/nw_check/output.py
+++ b/nw_check/output.py
@@ -1,0 +1,90 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""Output rendering for reports."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from nw_check.models import AsIsLink, LinkDiff
+
+
+def write_asis_links(path: str | Path, links: list[AsIsLink]) -> None:
+    """Write As-Is links CSV."""
+
+    with Path(path).open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            [
+                "local_device",
+                "local_port",
+                "remote_device",
+                "remote_port",
+                "confidence",
+                "evidence",
+            ]
+        )
+        for link in sorted(
+            links,
+            key=lambda item: (item.device_a, item.port_a, item.device_b, item.port_b),
+        ):
+            writer.writerow(
+                [
+                    link.device_a,
+                    link.port_a,
+                    link.device_b,
+                    link.port_b,
+                    link.confidence,
+                    ";".join(link.evidence),
+                ]
+            )
+
+
+def write_diff_links(path: str | Path, diffs: list[LinkDiff]) -> None:
+    """Write To-Be vs As-Is diff CSV."""
+
+    with Path(path).open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["device_a", "port_a", "device_b", "port_b", "status", "reason"])
+        for diff in sorted(
+            diffs,
+            key=lambda item: (
+                item.tobe_link.device_a,
+                item.tobe_link.port_a_norm,
+                item.tobe_link.device_b,
+                item.tobe_link.port_b_norm,
+            ),
+        ):
+            writer.writerow(
+                [
+                    diff.tobe_link.device_a,
+                    diff.tobe_link.port_a_norm,
+                    diff.tobe_link.device_b,
+                    diff.tobe_link.port_b_norm,
+                    diff.status,
+                    diff.reason,
+                ]
+            )
+
+
+def write_summary(path: str | Path, diffs: list[LinkDiff], errors: list[str]) -> None:
+    """Write summary report."""
+
+    lldp_failed_devices = sorted({error for error in errors})
+    missing_ports = sum(1 for diff in diffs if diff.status == "PARTIAL_OBSERVED")
+    mismatch_links = sum(1 for diff in diffs if diff.status != "EXACT_MATCH")
+
+    with Path(path).open("w", encoding="utf-8") as handle:
+        handle.write(f"lldp_failed_devices: {', '.join(lldp_failed_devices)}\n")
+        handle.write(f"missing_ports: {missing_ports}\n")
+        handle.write(f"mismatch_links: {mismatch_links}\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "nw-check"
+version = "0.1.0"
+description = "Network wiring validation via LLDP and CSV intents."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [{ name = "nw-check contributors" }]
+
+[project.scripts]
+nw-check = "nw_check.cli:main"
+
+[project.optional-dependencies]
+dev = [
+  "mypy>=1.10.0",
+  "pre-commit>=3.7.0",
+  "pylint>=3.2.0",
+  "pytest>=8.2.0",
+  "ruff>=0.5.0",
+]
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+strict = true
+
+[tool.pylint.main]
+py-version = "3.10"
+
+[tool.pylint."messages control"]
+disable = [
+  "too-few-public-methods",
+]
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,105 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""Tests for diff logic."""
+
+from nw_check.diff import (
+    STATUS_DEVICE_MISMATCH,
+    STATUS_EXACT_MATCH,
+    STATUS_MISSING_ASIS,
+    STATUS_PORT_MISMATCH,
+    diff_links,
+)
+from nw_check.models import AsIsLink, LinkIntent
+
+
+def test_diff_links_exact_match() -> None:
+    intent = LinkIntent(
+        device_a="leaf01",
+        port_a_raw="Eth1/1",
+        port_a_norm="Eth1/1",
+        device_b="spine01",
+        port_b_raw="Eth1/1",
+        port_b_norm="Eth1/1",
+    )
+    asis = AsIsLink(
+        device_a="leaf01",
+        port_a="Eth1/1",
+        device_b="spine01",
+        port_b="Eth1/1",
+        confidence="observed",
+        evidence=("lldp",),
+    )
+
+    result = diff_links([intent], [asis])
+
+    assert result[0].status == STATUS_EXACT_MATCH
+
+
+def test_diff_links_port_mismatch() -> None:
+    intent = LinkIntent(
+        device_a="leaf01",
+        port_a_raw="Eth1/1",
+        port_a_norm="Eth1/1",
+        device_b="spine01",
+        port_b_raw="Eth1/2",
+        port_b_norm="Eth1/2",
+    )
+    asis = AsIsLink(
+        device_a="leaf01",
+        port_a="Eth1/1",
+        device_b="spine01",
+        port_b="Eth1/3",
+        confidence="observed",
+        evidence=("lldp",),
+    )
+
+    result = diff_links([intent], [asis])
+
+    assert result[0].status == STATUS_PORT_MISMATCH
+
+
+def test_diff_links_device_mismatch() -> None:
+    intent = LinkIntent(
+        device_a="leaf01",
+        port_a_raw="Eth1/1",
+        port_a_norm="Eth1/1",
+        device_b="spine01",
+        port_b_raw="Eth1/2",
+        port_b_norm="Eth1/2",
+    )
+    asis = AsIsLink(
+        device_a="leaf02",
+        port_a="Eth1/1",
+        device_b="spine02",
+        port_b="Eth1/2",
+        confidence="observed",
+        evidence=("lldp",),
+    )
+
+    result = diff_links([intent], [asis])
+
+    assert result[0].status == STATUS_DEVICE_MISMATCH
+
+
+def test_diff_links_missing_asis() -> None:
+    intent = LinkIntent(
+        device_a="leaf01",
+        port_a_raw="Eth1/1",
+        port_a_norm="Eth1/1",
+        device_b="spine01",
+        port_b_raw="Eth1/2",
+        port_b_norm="Eth1/2",
+    )
+
+    result = diff_links([intent], [])
+
+    assert result[0].status == STATUS_MISSING_ASIS

--- a/tests/test_link_infer.py
+++ b/tests/test_link_infer.py
@@ -1,0 +1,73 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""Tests for deduplication logic."""
+
+from nw_check.link_infer import deduplicate_links
+from nw_check.models import LinkObservation
+
+
+def test_deduplicate_links_merges_bidirectional() -> None:
+    observations = [
+        LinkObservation(
+            local_device="leaf01",
+            local_port_raw="Eth1/1",
+            local_port_norm="Eth1/1",
+            remote_device_id="chassis1",
+            remote_device_name="spine01",
+            remote_port_raw="Eth1/1",
+            remote_port_norm="Eth1/1",
+            source="lldp",
+            confidence="observed",
+            errors=(),
+        ),
+        LinkObservation(
+            local_device="spine01",
+            local_port_raw="Eth1/1",
+            local_port_norm="Eth1/1",
+            remote_device_id="chassis2",
+            remote_device_name="leaf01",
+            remote_port_raw="Eth1/1",
+            remote_port_norm="Eth1/1",
+            source="lldp",
+            confidence="observed",
+            errors=(),
+        ),
+    ]
+
+    deduped = deduplicate_links(observations)
+
+    assert len(deduped) == 1
+    link = deduped[0]
+    assert link.confidence == "observed"
+    assert link.device_a == "leaf01"
+    assert link.device_b == "spine01"
+
+
+def test_deduplicate_links_handles_partial() -> None:
+    observations = [
+        LinkObservation(
+            local_device="leaf02",
+            local_port_raw="Eth1/1",
+            local_port_norm="Eth1/1",
+            remote_device_id="chassis3",
+            remote_device_name="unknown",
+            remote_port_raw="unknown",
+            remote_port_norm="unknown",
+            source="lldp",
+            confidence="partial",
+            errors=("LLDP_PARTIAL_ROW",),
+        )
+    ]
+
+    deduped = deduplicate_links(observations)
+
+    assert deduped[0].confidence == "partial"

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,27 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""Tests for interface normalization."""
+
+from nw_check.normalize import normalize_interface_name
+
+
+def test_normalize_interface_name_maps_prefixes() -> None:
+    assert normalize_interface_name("Eth1/1") == "Eth1/1"
+    assert normalize_interface_name("ethernet1/2") == "Eth1/2"
+    assert normalize_interface_name("Gi1/3") == "Eth1/3"
+    assert normalize_interface_name("GigabitEthernet1/4") == "Eth1/4"
+    assert normalize_interface_name("Te1-1") == "Eth1/1"
+
+
+def test_normalize_interface_name_handles_empty() -> None:
+    assert normalize_interface_name("") == "unknown"
+    assert normalize_interface_name("   ") == "unknown"


### PR DESCRIPTION
### Motivation

- Implement the core pipeline described in the README to produce deterministic As-Is and To-Be wiring reports from LLDP and CSV inputs.  
- Provide a minimal SNMP LLDP collection scaffold and normalization/deduplication/diff logic so the CLI can generate CSV and summary outputs.  
- Add unit tests and basic developer tooling to make behavior explicit and testable.

### Description

- Add core modules and CLI: `nw_check.models`, `nw_check.normalize`, `nw_check.inventory`, `nw_check.lldp_snmp`, `nw_check.link_infer`, `nw_check.diff`, `nw_check.output`, and `nw_check.cli`, implementing LLDP parsing (via `snmpwalk`), interface normalization, deduplication, To-Be vs As-Is diffing, and CSV/text output.  
- Add tests and project metadata: `tests/test_normalize.py`, `tests/test_link_infer.py`, `tests/test_diff.py`, `pyproject.toml`, `.pre-commit-config.yaml`, and `README.md` updates with a Getting Started/dev-commands section.  
- Replace `shlex.which` usage with `shutil.which` and tighten a few parsing/formatting spots (small refactors in `nw_check/lldp_snmp.py`, `nw_check/diff.py`, `nw_check/output.py`, etc.).  
- LLM involvement: the following files were created or modified with LLM assistance — `README.md`, `LICENSE`, `pyproject.toml`, `.pre-commit-config.yaml`, `nw_check/__init__.py`, `nw_check/cli.py`, `nw_check/diff.py`, `nw_check/inventory.py`, `nw_check/link_infer.py`, `nw_check/lldp_snmp.py`, `nw_check/models.py`, `nw_check/normalize.py`, `nw_check/output.py`, `tests/test_diff.py`, `tests/test_link_infer.py`, `tests/test_normalize.py`; these changes were reviewed and validated locally.

### Testing

- Ran unit tests with `python -m pytest` which passed (`8 passed`).  
- Ran static typing checks with `python -m mypy nw_check` which reported no issues.  
- Applied formatting and lint checks with `python -m ruff format` and `python -m ruff check nw_check tests`, where formatting was applied and `ruff` checks passed.  
- Attempted `python -m pylint nw_check` and `pre-commit run --all-files` but those tools were not available in the execution environment (reported as not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964abd334148330b6ff26a7d97ff32d)