### PR TITLE
Add device aliases, CSV validation, and improve LLDP matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@
 - Device identity normalization:
   - Prefer inventory device name as canonical.
   - Resolve LLDP `sysName` to inventory using exact match or configured alias map.
+    - Device inventory can include an `aliases` column with comma-separated names.
   - If only chassis ID is available, keep as `remote_device_id` and mark uncertainty.
 
 ## Link Inference + Deduplication

--- a/nw_check/inventory.py
+++ b/nw_check/inventory.py
@@ -15,9 +15,13 @@ from __future__ import annotations
 
 import csv
 from pathlib import Path
+from typing import Sequence
 
 from nw_check.models import Device, LinkIntent
 from nw_check.normalize import normalize_interface_name
+
+_DEVICE_REQUIRED_COLUMNS = ("name", "mgmt_ip", "snmp_version")
+_LINK_REQUIRED_COLUMNS = ("device_a", "port_a", "device_b", "port_b")
 
 
 def load_device_inventory(path: str | Path) -> list[Device]:
@@ -26,7 +30,11 @@ def load_device_inventory(path: str | Path) -> list[Device]:
     devices: list[Device] = []
     with Path(path).open(encoding="utf-8") as handle:
         reader = csv.DictReader(handle)
+        _validate_headers(path, reader.fieldnames, _DEVICE_REQUIRED_COLUMNS)
         for row in reader:
+            _validate_row(path, row, _DEVICE_REQUIRED_COLUMNS)
+            aliases_raw = (row.get("aliases") or "").strip()
+            aliases = tuple(alias.strip() for alias in aliases_raw.split(",") if alias.strip())
             device = Device(
                 name=(row.get("name") or "").strip(),
                 mgmt_ip=(row.get("mgmt_ip") or "").strip(),
@@ -35,6 +43,7 @@ def load_device_inventory(path: str | Path) -> list[Device]:
                 snmp_user=(row.get("snmp_user") or "").strip() or None,
                 snmp_auth=(row.get("snmp_auth") or "").strip() or None,
                 snmp_priv=(row.get("snmp_priv") or "").strip() or None,
+                aliases=aliases,
             )
             devices.append(device)
     return devices
@@ -46,7 +55,9 @@ def load_link_intents(path: str | Path) -> list[LinkIntent]:
     intents: list[LinkIntent] = []
     with Path(path).open(encoding="utf-8") as handle:
         reader = csv.DictReader(handle)
+        _validate_headers(path, reader.fieldnames, _LINK_REQUIRED_COLUMNS)
         for row in reader:
+            _validate_row(path, row, _LINK_REQUIRED_COLUMNS)
             device_a = (row.get("device_a") or "").strip()
             port_a_raw = (row.get("port_a") or "").strip()
             device_b = (row.get("device_b") or "").strip()
@@ -62,3 +73,36 @@ def load_link_intents(path: str | Path) -> list[LinkIntent]:
                 )
             )
     return intents
+
+
+def build_device_alias_map(devices: list[Device]) -> dict[str, str]:
+    """Build a case-insensitive alias map for device names."""
+
+    alias_map: dict[str, str] = {}
+    for device in devices:
+        alias_map[device.name.lower()] = device.name
+        for alias in device.aliases:
+            alias_map[alias.lower()] = device.name
+    return alias_map
+
+
+def _validate_headers(
+    path: str | Path,
+    fieldnames: Sequence[str] | None,
+    required: tuple[str, ...],
+) -> None:
+    """Ensure required headers are present."""
+
+    if fieldnames is None:
+        raise ValueError(f"{path} is missing header row")
+    missing = [name for name in required if name not in fieldnames]
+    if missing:
+        raise ValueError(f"{path} is missing required columns: {', '.join(missing)}")
+
+
+def _validate_row(path: str | Path, row: dict[str, str], required: tuple[str, ...]) -> None:
+    """Ensure required row fields are populated."""
+
+    missing = [name for name in required if not (row.get(name) or "").strip()]
+    if missing:
+        raise ValueError(f"{path} has empty required fields: {', '.join(missing)}")

--- a/nw_check/link_infer.py
+++ b/nw_check/link_infer.py
@@ -23,10 +23,15 @@ def deduplicate_links(observations: list[LinkObservation]) -> list[AsIsLink]:
 
     grouped: dict[tuple[str, str, str, str], list[LinkObservation]] = defaultdict(list)
     for obs in observations:
+        remote_device = (
+            obs.remote_device_id
+            if obs.remote_device_name == UNKNOWN_VALUE
+            else obs.remote_device_name
+        )
         device_a, port_a, device_b, port_b = _canonicalize(
             obs.local_device,
             obs.local_port_norm,
-            obs.remote_device_name or obs.remote_device_id,
+            remote_device,
             obs.remote_port_norm,
         )
         grouped[(device_a, port_a, device_b, port_b)].append(obs)

--- a/nw_check/models.py
+++ b/nw_check/models.py
@@ -30,6 +30,7 @@ class Device:
     snmp_user: str | None = None
     snmp_auth: str | None = None
     snmp_priv: str | None = None
+    aliases: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/nw_check/output.py
+++ b/nw_check/output.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import csv
 from pathlib import Path
 
-from nw_check.models import AsIsLink, LinkDiff
+from nw_check.models import UNKNOWN_VALUE, AsIsLink, LinkDiff
 
 
 def write_asis_links(path: str | Path, links: list[AsIsLink]) -> None:
@@ -77,11 +77,18 @@ def write_diff_links(path: str | Path, diffs: list[LinkDiff]) -> None:
             )
 
 
-def write_summary(path: str | Path, diffs: list[LinkDiff], errors: list[str]) -> None:
+def write_summary(
+    path: str | Path,
+    diffs: list[LinkDiff],
+    errors: list[str],
+    asis_links: list[AsIsLink],
+) -> None:
     """Write summary report."""
 
     lldp_failed_devices = sorted({error for error in errors})
-    missing_ports = sum(1 for diff in diffs if diff.status == "PARTIAL_OBSERVED")
+    missing_ports = sum(
+        1 for link in asis_links for port in (link.port_a, link.port_b) if port == UNKNOWN_VALUE
+    )
     mismatch_links = sum(1 for diff in diffs if diff.status != "EXACT_MATCH")
 
     with Path(path).open("w", encoding="utf-8") as handle:

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -16,6 +16,7 @@ from nw_check.diff import (
     STATUS_EXACT_MATCH,
     STATUS_MISSING_ASIS,
     STATUS_PORT_MISMATCH,
+    STATUS_PARTIAL_OBSERVED,
     diff_links,
 )
 from nw_check.models import AsIsLink, LinkIntent
@@ -103,3 +104,27 @@ def test_diff_links_missing_asis() -> None:
     result = diff_links([intent], [])
 
     assert result[0].status == STATUS_MISSING_ASIS
+
+
+def test_diff_links_partial_includes_candidate_details() -> None:
+    intent = LinkIntent(
+        device_a="leaf01",
+        port_a_raw="Eth1/1",
+        port_a_norm="Eth1/1",
+        device_b="spine01",
+        port_b_raw="Eth1/1",
+        port_b_norm="Eth1/1",
+    )
+    asis = AsIsLink(
+        device_a="leaf01",
+        port_a="Eth1/1",
+        device_b="chassis-raw",
+        port_b="unknown",
+        confidence="partial",
+        evidence=("lldp",),
+    )
+
+    result = diff_links([intent], [asis])
+
+    assert result[0].status == STATUS_PARTIAL_OBSERVED
+    assert "chassis-raw" in result[0].reason

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,65 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""Tests for inventory parsing."""
+
+from pathlib import Path
+
+import pytest
+
+from nw_check.inventory import build_device_alias_map, load_device_inventory, load_link_intents
+
+
+def test_load_device_inventory_parses_aliases(tmp_path: Path) -> None:
+    csv_path = tmp_path / "devices.csv"
+    csv_path.write_text(
+        "name,mgmt_ip,snmp_version,snmp_community,aliases\n"
+        'leaf01,10.0.0.1,2c,public,"leaf-1,leaf-one"\n',
+        encoding="utf-8",
+    )
+
+    devices = load_device_inventory(csv_path)
+
+    assert devices[0].aliases == ("leaf-1", "leaf-one")
+
+    alias_map = build_device_alias_map(devices)
+    assert alias_map["leaf01"] == "leaf01"
+    assert alias_map["leaf-1"] == "leaf01"
+
+
+def test_load_device_inventory_requires_fields(tmp_path: Path) -> None:
+    csv_path = tmp_path / "devices.csv"
+    csv_path.write_text("name,mgmt_ip\nleaf01,10.0.0.1\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing required columns"):
+        load_device_inventory(csv_path)
+
+
+def test_load_link_intents_requires_fields(tmp_path: Path) -> None:
+    csv_path = tmp_path / "tobe.csv"
+    csv_path.write_text(
+        "device_a,device_b,port_b\nleaf01,spine01,Eth1/1\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="missing required columns"):
+        load_link_intents(csv_path)
+
+
+def test_load_link_intents_requires_values(tmp_path: Path) -> None:
+    csv_path = tmp_path / "tobe.csv"
+    csv_path.write_text(
+        "device_a,port_a,device_b,port_b\nleaf01,,spine01,Eth1/1\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="empty required fields"):
+        load_link_intents(csv_path)

--- a/tests/test_link_infer.py
+++ b/tests/test_link_infer.py
@@ -71,3 +71,24 @@ def test_deduplicate_links_handles_partial() -> None:
     deduped = deduplicate_links(observations)
 
     assert deduped[0].confidence == "partial"
+
+
+def test_deduplicate_links_uses_remote_device_id_when_name_unknown() -> None:
+    observations = [
+        LinkObservation(
+            local_device="leaf03",
+            local_port_raw="Eth1/2",
+            local_port_norm="Eth1/2",
+            remote_device_id="chassis99",
+            remote_device_name="unknown",
+            remote_port_raw="Eth1/10",
+            remote_port_norm="Eth1/10",
+            source="lldp",
+            confidence="partial",
+            errors=("LLDP_PARTIAL_ROW",),
+        )
+    ]
+
+    deduped = deduplicate_links(observations)
+
+    assert "chassis99" in {deduped[0].device_a, deduped[0].device_b}

--- a/tests/test_lldp_snmp.py
+++ b/tests/test_lldp_snmp.py
@@ -1,0 +1,43 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""Tests for LLDP SNMP parsing utilities."""
+
+from nw_check.lldp_snmp import _parse_loc_port_table, _parse_rem_table, _resolve_device_name
+
+
+def test_resolve_device_name_uses_alias_map() -> None:
+    alias_map = {"leaf01": "leaf01", "leaf-1": "leaf01"}
+
+    assert _resolve_device_name("leaf-1", alias_map) == "leaf01"
+
+
+def test_parse_loc_port_table_extracts_ports() -> None:
+    lines = ["LLDP-MIB::lldpLocPortId.1.1 = STRING: Eth1/1"]
+
+    ports = _parse_loc_port_table(lines)
+
+    assert ports["1.1"] == "Eth1/1"
+
+
+def test_parse_rem_table_groups_rows() -> None:
+    lines = [
+        "LLDP-MIB::lldpRemChassisId.0.10.1 = STRING: chassisA",
+        "LLDP-MIB::lldpRemPortId.0.10.1 = STRING: Eth1/1",
+        "LLDP-MIB::lldpRemSysName.0.10.1 = STRING: spine01",
+    ]
+
+    rows = _parse_rem_table(lines)
+
+    assert rows[0].local_port == "10"
+    assert rows[0].remote_chassis == "chassisA"
+    assert rows[0].remote_port == "Eth1/1"
+    assert rows[0].remote_sys_name == "spine01"

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,52 @@
+# Copyright 2025 nw-check contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+"""Tests for output rendering."""
+
+from pathlib import Path
+
+from nw_check.models import AsIsLink, LinkDiff, LinkIntent
+from nw_check.output import write_summary
+
+
+def test_write_summary_counts_missing_ports(tmp_path: Path) -> None:
+    diff = LinkDiff(
+        tobe_link=LinkIntent(
+            device_a="leaf01",
+            port_a_raw="Eth1/1",
+            port_a_norm="Eth1/1",
+            device_b="spine01",
+            port_b_raw="Eth1/1",
+            port_b_norm="Eth1/1",
+        ),
+        asis_link=None,
+        status="MISSING_ASIS",
+        reason="no lldp observation",
+    )
+    asis_links = [
+        AsIsLink(
+            device_a="leaf01",
+            port_a="unknown",
+            device_b="spine01",
+            port_b="Eth1/1",
+            confidence="partial",
+            evidence=("lldp",),
+        )
+    ]
+
+    summary_path = tmp_path / "summary.txt"
+
+    write_summary(summary_path, [diff], ["leaf01"], asis_links)
+
+    content = summary_path.read_text(encoding="utf-8")
+    assert "missing_ports: 1" in content
+    assert "lldp_failed_devices: leaf01" in content
+    assert "mismatch_links: 1" in content


### PR DESCRIPTION
### Motivation
- Resolve LLDP `sysName` to canonical inventory names (including aliases) and preserve chassis IDs when name is missing.
- Fail fast on malformed CSV inputs so the CLI can return a clear error code for invalid inventory or To-Be files.
- Surface richer reasons for partial LLDP observations and accurately count unknown remote ports in summaries.
- Provide unit test coverage for inventory parsing, LLDP parsing, deduplication, diff logic, and output generation.

### Description
- Add an `aliases` field to the `Device` model and parse an `aliases` CSV column in `load_device_inventory`, plus implement `build_device_alias_map` for case-insensitive alias lookup.
- Validate CSV header presence and required row values in `load_device_inventory` and `load_link_intents`, raising `ValueError` on invalid input and returning exit code `3` from `main` when validation fails.
- Thread an `alias_map` into `collect_lldp_observations` and resolve LLDP `sysName` via `_resolve_device_name`, and prefer `remote_device_id` when `remote_device_name` is `unknown` in `deduplicate_links`.
- Improve candidate matching in `diff_links` to include partial/unknown fields, add `_partial_reason` to include candidate details in the reason, and update `write_summary` to count unknown ports from `asis_links`.

### Testing
- Ran unit tests with `pytest` and all tests passed (`18 passed`).
- Ran static type checks with `mypy` (`python -m mypy nw_check`) and no issues were reported.
- Applied formatting with `ruff` (`python -m ruff format`) which reformatted files as needed.
- Attempted to run `pylint` but installation failed due to network/proxy restrictions, so linting was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964bb7bf87c8330b99fc6abfd0cab26)