### PR TITLE
Configure pytest pythonpath and fix import order in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,6 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -15,8 +15,8 @@ from nw_check.diff import (
     STATUS_DEVICE_MISMATCH,
     STATUS_EXACT_MATCH,
     STATUS_MISSING_ASIS,
-    STATUS_PORT_MISMATCH,
     STATUS_PARTIAL_OBSERVED,
+    STATUS_PORT_MISMATCH,
     diff_links,
 )
 from nw_check.models import AsIsLink, LinkIntent


### PR DESCRIPTION
### Motivation
- Pytest collection failed with `ModuleNotFoundError` because test collection did not include the repository root on `PYTHONPATH`.
- Ruff reported an unsorted import block in `tests/test_diff.py`, causing lint failures.
- The change ensures tests are discoverable and linting passes so CI and local runs succeed.

### Description
- Add a `pythonpath = ["."]` pytest config under `[tool.pytest.ini_options]` in `pyproject.toml` to include the repo root for test imports.
- Reorder the imports in `tests/test_diff.py` to satisfy `ruff` import organization rules.
- Files modified with LLM assistance: `pyproject.toml`, `tests/test_diff.py`; this change should be reviewed for correctness and security.

### Testing
- Ran `pytest -q` which succeeded: `18 passed`.
- Ran `ruff check .` which passed after fixing the import order, and `ruff format .` was applied.
- Ran `mypy nw_check` which reported `Success: no issues found`.
- Attempted `pylint nw_check` and `pre-commit run --all-files` but they could not be executed in the environment due to missing tools (not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964cbaac3a083309d96956c8ba0579f)