### PR TITLE
Add SNMPv3 support for LLDP collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - No continuous discovery; only manual execution for initial build and wiring changes.
 - No real-time correlation with interface state (up/down) beyond LLDP availability.
 - No vendor-specific proprietary discovery beyond standard LLDP-MIB in initial scope.
-- SNMPv3 support is deferred to a later phase; design should allow extension.
+- SNMPv1, v2c, and v3 are supported for LLDP collection.
 
 ## Data Model
 
@@ -35,7 +35,7 @@
 - **Device**
   - `name`: canonical device name from inventory
   - `mgmt_ip`: management IP address
-  - `snmp`: version and credentials
+- `snmp`: version and credentials (community for v1/v2c, user/auth/priv for v3)
 - **Interface**
   - `device`: canonical device name
   - `name_raw`: raw interface name
@@ -152,6 +152,18 @@
 2. Ensure the `snmpwalk` CLI is available on your PATH for LLDP collection.
 3. Run the CLI with your inventory and intent CSVs:
    - `nw-check --devices devices.csv --tobe tobe.csv --out-dir out/`
+
+### Device Inventory CSV
+
+Columns:
+- `name` (required)
+- `mgmt_ip` (required)
+- `snmp_version` (required; `1`, `2c`, or `3`)
+- `snmp_community` (required for SNMPv1/v2c)
+- `snmp_user` (required for SNMPv3)
+- `snmp_auth` (optional for SNMPv3, format `protocol:secret`, e.g. `sha:authpass`)
+- `snmp_priv` (optional for SNMPv3, format `protocol:secret`, e.g. `aes:privpass`)
+- `aliases` (optional, comma-separated)
 
 ### Development Commands
 

--- a/samples/devices.csv
+++ b/samples/devices.csv
@@ -1,3 +1,3 @@
-name,mgmt_ip,snmp_version,snmp_community,aliases
-leaf01,10.0.0.1,2c,public,"leaf-1,leaf-one"
-spine01,10.0.0.2,2c,public,spine-1
+name,mgmt_ip,snmp_version,snmp_community,snmp_user,snmp_auth,snmp_priv,aliases
+leaf01,10.0.0.1,2c,public,,,,"leaf-1,leaf-one"
+spine01,10.0.0.2,3,,snmpuser,sha:authpass,aes:privpass,spine-1


### PR DESCRIPTION
### Motivation

- Enable SNMPv3-based LLDP collection so environments that forbid community strings can be supported.
- Prevent running `snmpwalk` with incomplete credentials by validating SNMP auth/priv fields before collection.
- Extend inventory and documentation so users can declare SNMPv1/v2c/v3 credentials in CSVs.

### Description

- Add credential validation and command construction: `_validate_snmp_credentials`, `_build_snmpwalk_command`, `_snmpv3_args`, and `_parse_snmpv3_credential`, and wire them into `_collect_for_device` and `_run_snmpwalk` to support v1/v2c/v3 flows.
- Construct `snmpwalk` CLI args for SNMPv3 (levels `noAuthNoPriv` / `authNoPriv` / `authPriv`) and map `snmp_version` values `1`, `2c`, `3` to the correct `-v` flag.
- Update documentation and samples: add SNMPv3 inventory fields to `README.md` and expand `samples/devices.csv`; add unit test `test_build_snmpwalk_command_snmpv3_auth_priv` in `tests/test_lldp_snmp.py`.
- LLM involvement: modified files `nw_check/lldp_snmp.py`, `tests/test_lldp_snmp.py`, `README.md`, and `samples/devices.csv`; this work was produced with LLM assistance and requires human review for correctness and security.

### Testing

- Formatting: ran `python -m ruff format` (succeeded).
- Static typing: ran `python -m mypy nw_check` (succeeded).
- Unit tests: ran `python -m pytest` (19 passed, all tests green).
- Lint/pre-commit: ran `python -m pylint nw_check` and `python -m pre_commit run --all-files` but they could not run in the environment due to missing tools (modules not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965ba44b29483308175608ecf1c9a27)